### PR TITLE
Clarify what's necessary for mount_uploaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gem 'carrierwave'
 
 Finally, restart the server to apply the changes.
 
-As of version 1.0.0, CarrierWave requires Rails 4.0 or higher and Ruby 2.0
+As of version 1.0.0 (forthcoming), CarrierWave requires Rails 4.0 or higher and Ruby 2.0
 or higher. If you're on Rails 3, you should use v0.10.0.
 
 ## Getting Started
@@ -132,6 +132,9 @@ Other ORM support has been extracted into separate gems:
 There are more extensions listed in [the wiki](https://github.com/carrierwaveuploader/carrierwave/wiki)
 
 ## Multiple file uploads
+**Note:** You must specify using the master branch to enable this feature: 
+
+`gem carrierwave, github:'carrierwaveuploader/carrierwave'`.
 
 CarrierWave also has convenient support for multiple file upload fields.
 


### PR DESCRIPTION
The README on master talks about things you can't have in the latest stable. This PR tries to make it more clear in an effort to prevent people from submitting issues like #1551 over and over.
- Add a line clarifying that 1.0.0 is still forthcoming
- Add a line clarifying how to bundle the gem so that the multiple uploader support referenced in the README is available.
